### PR TITLE
Fixes for Chef 13 deprecated features

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -21,7 +21,7 @@ maintainer_email 'go-cd@googlegroups.com'
 version          '2.0.0'
 source_url       'https://github.com/gocd-contrib/go-cookbook' if respond_to?(:source_url)
 issues_url       'https://github.com/gocd-contrib/go-cookbook/issues' if respond_to?(:issues_url)
-chef_version     '~> 12'
+chef_version     '>= 12'
 license          'Apache-2.0'
 
 supports 'ubuntu'

--- a/recipes/agent_linux_install.rb
+++ b/recipes/agent_linux_install.rb
@@ -14,6 +14,8 @@
 # limitations under the License.
 ##########################################################################
 
+include_recipe 'gocd::ohai'
+
 case node['gocd']['agent']['type']
 when 'java'
   include_recipe 'gocd::java' if node['gocd']['agent']['type'] == 'java'

--- a/recipes/agent_linux_install.rb
+++ b/recipes/agent_linux_install.rb
@@ -14,11 +14,6 @@
 # limitations under the License.
 ##########################################################################
 
-ohai 'reload_passwd_for_go_user' do
-  action :nothing
-  plugin 'etc'
-end
-
 case node['gocd']['agent']['type']
 when 'java'
   include_recipe 'gocd::java' if node['gocd']['agent']['type'] == 'java'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -14,5 +14,10 @@
 # limitations under the License.
 ##########################################################################
 
+ohai 'reload_passwd_for_go_user' do
+  action :nothing
+  plugin 'etc'
+end
+
 include_recipe 'gocd::server'
 include_recipe 'gocd::agent'

--- a/recipes/ohai.rb
+++ b/recipes/ohai.rb
@@ -14,5 +14,7 @@
 # limitations under the License.
 ##########################################################################
 
-include_recipe 'gocd::server'
-include_recipe 'gocd::agent'
+ohai 'reload_passwd_for_go_user' do
+  action :nothing
+  plugin 'etc'
+end

--- a/recipes/server_linux_install.rb
+++ b/recipes/server_linux_install.rb
@@ -15,6 +15,7 @@
 ##########################################################################
 
 include_recipe 'gocd::java'
+include_recipe 'gocd::ohai'
 
 package 'unzip'
 

--- a/recipes/server_linux_install.rb
+++ b/recipes/server_linux_install.rb
@@ -16,12 +16,6 @@
 
 include_recipe 'gocd::java'
 
-ohai 'reload_passwd_for_go_user' do
-  name 'reload_passwd'
-  action :nothing
-  plugin 'etc'
-end
-
 package 'unzip'
 
 case node['gocd']['install_method']

--- a/resources/agent.rb
+++ b/resources/agent.rb
@@ -29,9 +29,7 @@ property :daemon, kind_of: [TrueClass, FalseClass], required: false, default: no
 property :vnc, kind_of: [TrueClass, FalseClass], required: false, default: node['gocd']['agent']['vnc']['enabled']
 property :autoregister_key, kind_of: String, required: false, default: nil
 property :autoregister_hostname, kind_of: String, required: false, default: nil
-property :environments, kind_of: [String, Array], required: false, default: nil # deprecated in favour of autoreigster_environments
 property :autoregister_environments, kind_of: [String, Array], required: false, default: nil
-property :resources, kind_of: [String, Array], required: false, default: nil # deprecated in favour of autoregister_resources
 property :autoregister_resources, kind_of: [String, Array], required: false, default: nil
 property :workspace, kind_of: String, required: false, default: nil
 property :elastic_agent_id, kind_of: [String, nil], required: false, default: nil
@@ -121,8 +119,8 @@ action :create do
       group new_resource.group
       autoregister_key new_resource.autoregister_key
       autoregister_hostname new_resource.autoregister_hostname
-      autoregister_environments new_resource.autoregister_environments || new_resource.environments
-      autoregister_resources new_resource.autoregister_resources || new_resource.resources
+      autoregister_environments new_resource.autoregister_environments
+      autoregister_resources new_resource.autoregister_resources
       elastic_agent_id new_resource.elastic_agent_id
       elastic_agent_plugin_id new_resource.elastic_agent_plugin_id
       not_if { ::File.exist? proof_of_registration }

--- a/resources/agent_autoregister_file.rb
+++ b/resources/agent_autoregister_file.rb
@@ -24,9 +24,7 @@ property :owner, kind_of: String, required: false, default: 'go'
 property :group, kind_of: String, required: false, default: 'go'
 property :autoregister_key, kind_of: String, required: true, default: nil
 property :autoregister_hostname, kind_of: String, required: false, default: nil
-property :environments, kind_of: [String, Array], required: false, default: nil # deprecated in favour of autoreigster_environments
 property :autoregister_environments, kind_of: [String, Array], required: false, default: nil
-property :resources, kind_of: [String, Array], required: false, default: nil # deprecated in favour of autoreigster_resources
 property :autoregister_resources, kind_of: [String, Array], required: false, default: nil
 property :elastic_agent_id, kind_of: [String, nil], required: false, default: nil
 property :elastic_agent_plugin_id, kind_of: [String, nil], required: false, default: nil
@@ -35,8 +33,8 @@ action :create do
   autoregister_values = agent_properties
   autoregister_values[:key] = new_resource.autoregister_key || autoregister_values[:key]
   autoregister_values[:hostname] = new_resource.autoregister_hostname || autoregister_values[:hostname]
-  autoregister_values[:autoregister_environments] = new_resource.autoregister_environments || new_resource.environments || autoregister_values[:environments]
-  autoregister_values[:autoregister_resources] = new_resource.autoregister_resources || new_resource.resources || autoregister_values[:resources]
+  autoregister_values[:autoregister_environments] = new_resource.autoregister_environments || autoregister_values[:environments]
+  autoregister_values[:autoregister_resources] = new_resource.autoregister_resources || autoregister_values[:resources]
   autoregister_values[:elastic_agent_id] = new_resource.elastic_agent_id || autoregister_values[:elastic_agent_id]
   autoregister_values[:elastic_agent_plugin_id] = new_resource.elastic_agent_plugin_id || autoregister_values[:elastic_agent_plugin_id]
 

--- a/spec/go_agent_autoregister_lwrp_spec.rb
+++ b/spec/go_agent_autoregister_lwrp_spec.rb
@@ -32,8 +32,8 @@ describe 'gocd_test::agent_autoregister_file_lwrp' do
       expect(chef_run).to create_gocd_agent_autoregister_file('/var/mygo/autoregister.properties').with(
         autoregister_key: 'bla-key',
         autoregister_hostname: 'mygo-agent',
-        environments: 'stage',
-        resources:     ['java-8', 'ruby']
+        autoregister_environments: 'stage',
+        autoregister_resources:     ['java-8', 'ruby']
       )
     end
 
@@ -51,8 +51,8 @@ describe 'gocd_test::agent_autoregister_file_lwrp' do
       expect(chef_run).to create_gocd_agent_autoregister_file('/var/elastic/autoregister.properties').with(
         autoregister_key: 'some-key',
         autoregister_hostname: 'elastic-agent',
-        environments: 'testing',
-        resources:     ['java-8']
+        autoregister_environments: 'testing',
+        autoregister_resources:     ['java-8']
       )
     end
 
@@ -114,8 +114,8 @@ describe 'gocd_test::agent_autoregister_file_lwrp' do
       expect(chef_run).to create_gocd_agent_autoregister_file('/var/mygo/autoregister.properties').with(
         autoregister_key: 'bla-key',
         autoregister_hostname: 'mygo-agent',
-        environments: 'stage',
-        resources:     ['java-8', 'ruby']
+        autoregister_environments: 'stage',
+        autoregister_resources:     ['java-8', 'ruby']
       )
     end
 
@@ -133,8 +133,8 @@ describe 'gocd_test::agent_autoregister_file_lwrp' do
       expect(chef_run).to create_gocd_agent_autoregister_file('/var/elastic/autoregister.properties').with(
         autoregister_key: 'some-key',
         autoregister_hostname: 'elastic-agent',
-        environments: 'testing',
-        resources:     ['java-8']
+        autoregister_environments: 'testing',
+        autoregister_resources:     ['java-8']
       )
     end
 

--- a/spec/go_server_spec.rb
+++ b/spec/go_server_spec.rb
@@ -21,6 +21,9 @@ describe 'gocd::server' do
     it 'includes java recipe' do
       expect(chef_run).to include_recipe('java::default')
     end
+    it 'includes the gocd::ohai recipe' do
+      expect(chef_run).to include_recipe('gocd::ohai')
+    end
     it 'creates go server configuration in /etc/default/go-server' do
       expect(chef_run).to render_file('/etc/default/go-server').with_content { |content|
         expect(content).to_not include('java-6')

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -75,6 +75,10 @@ shared_examples_for :agent_linux_install do
     expect(chef_run).to include_recipe('java::default')
   end
 
+  it 'includes the gocd::ohai recipe' do
+    expect(chef_run).to include_recipe('gocd::ohai')
+  end
+
   it 'includes gocd::agent_linux_install recipe' do
     expect(chef_run).to include_recipe('gocd::agent_linux_install')
   end

--- a/test/test_cookbook/recipes/agent_autoregister_file_lwrp.rb
+++ b/test/test_cookbook/recipes/agent_autoregister_file_lwrp.rb
@@ -17,15 +17,15 @@
 gocd_agent_autoregister_file '/var/mygo/autoregister.properties' do
   autoregister_key 'bla-key'
   autoregister_hostname 'mygo-agent'
-  environments 'stage'
-  resources ['java-8', 'ruby']
+  autoregister_environments 'stage'
+  autoregister_resources ['java-8', 'ruby']
 end
 
 gocd_agent_autoregister_file '/var/elastic/autoregister.properties' do
   autoregister_key 'some-key'
   autoregister_hostname 'elastic-agent'
-  environments 'testing'
-  resources ['java-8']
+  autoregister_environments 'testing'
+  autoregister_resources ['java-8']
   elastic_agent_id 'agent-id'
   elastic_agent_plugin_id 'elastic-agent-plugin-id'
 end

--- a/test/test_cookbook/recipes/single_agent_lwrp.rb
+++ b/test/test_cookbook/recipes/single_agent_lwrp.rb
@@ -20,7 +20,7 @@ gocd_agent 'my-go-agent' do
   vnc    true
   autoregister_key 'bla-key'
   autoregister_hostname 'my-lwrp-agent'
-  environments 'production'
-  resources     ['java-8', 'ruby-2.2']
+  autoregister_environments 'production'
+  autoregister_resources     ['java-8', 'ruby-2.2']
   workspace     '/mnt/big_drive'
 end

--- a/test/test_cookbook/recipes/single_agent_lwrp.rb
+++ b/test/test_cookbook/recipes/single_agent_lwrp.rb
@@ -21,6 +21,6 @@ gocd_agent 'my-go-agent' do
   autoregister_key 'bla-key'
   autoregister_hostname 'my-lwrp-agent'
   autoregister_environments 'production'
-  autoregister_resources     ['java-8', 'ruby-2.2']
-  workspace     '/mnt/big_drive'
+  autoregister_resources ['java-8', 'ruby-2.2']
+  workspace '/mnt/big_drive'
 end


### PR DESCRIPTION
These changes remove the features that are broken now with Chef 13 being released.

I did not want to bump the version number since you likely have a plan for that already, but if desired I can add another commit that adjusts the version number.