### PR TITLE
Add "export" to variables

### DIFF
--- a/templates/default/go-agent-default.erb
+++ b/templates/default/go-agent-default.erb
@@ -14,5 +14,5 @@ DAEMON=<%=  @daemon ? 'Y' : 'N' %>
 VNC=<%=     @vnc ? 'Y' : 'N' %>
 <% end %>
 <% node['gocd']['agent']['default_extras'].each do |k, v| %>
-<%= k %>="<%= v %>"
+export <%= k %>="<%= v %>"
 <% end %>


### PR DESCRIPTION
Agent can't pick up the variables in the job without export the variable