### PR TITLE
Windows plugin support

### DIFF
--- a/recipes/server_windows_install.rb
+++ b/recipes/server_windows_install.rb
@@ -15,15 +15,17 @@
 ##########################################################################
 
 package_path = File.join(Chef::Config[:file_cache_path], go_server_package_name)
-
+server_directory_path = node['gocd']['server']['work_dir'].tr('/', '\\')
 remote_file go_server_package_name do
   path package_path
   source go_server_package_url
 end
 
+log "Installing server to: #{server_directory_path}"
+
 opts = []
 opts << '/S'
-opts << "/D='#{node['gocd']['server']['work_dir'].tr('/', '\\')}'"
+opts << "/D=#{server_directory_path}"
 
 windows_package 'Go Server' do
   installer_type :nsis

--- a/resources/plugin.rb
+++ b/resources/plugin.rb
@@ -23,16 +23,26 @@ property :plugin_uri, kind_of: String, required: true
 property :server_work_dir, kind_of: String, required: false, default: node['gocd']['server']['work_dir']
 
 action :create do
-  include_recipe 'gocd::server_linux_install'
+  unless node['platform_family'].include?('windows')
+    include_recipe 'gocd::server_linux_install'
+  end
 
   plugin_name = new_resource.plugin_name
   server_work_dir = new_resource.server_work_dir
   plugin_uri = new_resource.plugin_uri
-  remote_file "#{server_work_dir}/plugins/external/#{plugin_name}.jar" do
-    source plugin_uri
-    owner 'go'
-    group 'go'
-    mode 0770
-    retries 5
+
+  if node['platform_family'].include?('windows')
+    remote_file "#{server_work_dir}\\plugins\\external\\#{plugin_name}.jar" do
+      source plugin_uri
+      retries 5
+    end
+  else
+    remote_file "#{server_work_dir}/plugins/external/#{plugin_name}.jar" do
+      source plugin_uri
+      owner 'go'
+      group 'go'
+      mode 0770
+      retries 5
+    end
   end
 end


### PR DESCRIPTION
•Fix installer argument to pass properly formatted path to installation directory on Windows OS.
•Skip installation of server for Linux when installing plugins on Windows OS.
•Fix installation of plugins on Windows OS.
