### PR TITLE
Remove spec that was checking redirection to /go/home while testing the agents.

### DIFF
--- a/test/integration/default/serverspec/go_autoregister_spec.rb
+++ b/test/integration/default/serverspec/go_autoregister_spec.rb
@@ -20,9 +20,6 @@ require 'serverspec'
 set :backend, :exec
 
 describe 'go server agents tab' do
-  describe command('curl -L localhost:8153/go') do
-    its(:stdout) { should contain('/go/home') }
-  end
   describe command('curl -H \'Accept: application/vnd.go.cd.v4+json\' localhost:8153/go/api/agents') do
     its(:stdout) { should contain('/var/lib/go-agent') }
     its(:stdout) { should contain('Idle') }


### PR DESCRIPTION
@tomzo - not sure why this spec was there in the first place. 

Since they spring security upgrade in GoCD 18.6.0, this no longer happens. `curl -L localhost:8153/go` yields the html for the add pipeline.

Edit: html for add pipeline, not dashboard.